### PR TITLE
Typings don't line up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-boop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Extended react hook for Josh Comeau's boop effect",
   "author": "remziatay",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { SpringValue, useSpring } from 'react-spring';
 import usePrefersReducedMotion from './use-prefers-reduced-motion';
 
@@ -23,9 +23,11 @@ interface Args {
   };
   delay?: number;
 }
-type SpringStyle = {
-  transform: SpringValue<string>;
-};
+type SpringStyle =
+  | {
+      transform: SpringValue<string>;
+    }
+  | {};
 export type BoopTuple = [SpringStyle, () => (() => void) | undefined];
 
 const useBoop: (args: Args) => BoopTuple = function ({
@@ -51,7 +53,7 @@ const useBoop: (args: Args) => BoopTuple = function ({
 }) {
   const prefersReducedMotion = usePrefersReducedMotion();
   const [isBooped, setIsBooped] = useState(false);
-  let style: CSSProperties = useSpring({
+  let style: SpringStyle = useSpring({
     transform: isBooped
       ? `translate3D(${x}px, ${y}px, ${z}px)
          rotateX(${rx}deg) rotateY(${ry}deg) rotateZ(${rz}deg)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { CSSProperties, useCallback, useEffect, useState } from 'react';
-import { useSpring } from 'react-spring';
+import { SpringValue, useSpring } from 'react-spring';
 import usePrefersReducedMotion from './use-prefers-reduced-motion';
 
 interface Args {
@@ -23,8 +23,10 @@ interface Args {
   };
   delay?: number;
 }
-
-export type BoopTuple = [CSSProperties, () => (() => void) | undefined];
+type SpringStyle = {
+  transform: SpringValue<string>;
+};
+export type BoopTuple = [SpringStyle, () => (() => void) | undefined];
 
 const useBoop: (args: Args) => BoopTuple = function ({
   x = 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, CSSProperties } from 'react';
+import { CSSProperties, useCallback, useEffect, useState } from 'react';
 import { useSpring } from 'react-spring';
 import usePrefersReducedMotion from './use-prefers-reduced-motion';
 
@@ -24,9 +24,9 @@ interface Args {
   delay?: number;
 }
 
-const useBoop: (
-  args: Args
-) => (CSSProperties | (() => (() => void) | undefined))[] = function ({
+export type BoopTuple = [CSSProperties, () => (() => void) | undefined];
+
+const useBoop: (args: Args) => BoopTuple = function ({
   x = 0,
   y = 0,
   z = 0,


### PR DESCRIPTION
I was using your package in a typescript project of mine and the hook was unuseable because of the typings. These changes made it work properly. 